### PR TITLE
chore: stoplight config

### DIFF
--- a/.stoplight.json
+++ b/.stoplight.json
@@ -1,3 +1,18 @@
 {
-  "exclude": [".github"]
+  "formats": {
+    "openapi": {
+      "rootDir": "reference"
+    },
+    "markdown": {
+      "rootDir": "docs",
+      "include": ["README.md", "docs/**"]
+    },
+    "image": {
+      "rootDir": "assets/images",
+      "include": ["**"]
+    },
+    "json_schema": {
+      "rootDir": "models"
+    }
+  }
 }


### PR DESCRIPTION
this will let us have autopublish back without worrying about test files showing up in docs.