### PR TITLE
Adding trailing slash to exclude list

### DIFF
--- a/docs/Basics/03-stoplight-config.md
+++ b/docs/Basics/03-stoplight-config.md
@@ -82,6 +82,6 @@ To exclude the test files and make it clear which other files are which, the fol
       "rootDir": "help"
     },
   },
-  "exclude": ["test"]
+  "exclude": ["/test"]
 }
 ```


### PR DESCRIPTION
As pointed out by this Bug: https://github.com/stoplightio/studio/issues/368, the `exclude` list needs a trailing slash to work.