### PR TITLE
add link to new Bug Report URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Buy us a tree](https://img.shields.io/badge/Buy%20us%20a%20tree-%F0%9F%8C%B3-lightgreen)](https://offset.earth/stoplightinc)
 
-To report a bug, please go to https://support.stoplight.io
+To report a bug, please go to https://support.stoplight.io/hc/en-us/requests/new
 
 Studio is Stoplight's next generation application for API design, modeling, and technical writing. A primary goal of Studio is to enrich, not replace, your existing workflows. When running locally it works fully offline, with folders and files on your computer just like your favorite IDE. When running in the browser, the web-native Git support allows you to effortlessly work with your existing repositories safely and efficiently.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Buy us a tree](https://img.shields.io/badge/Buy%20us%20a%20tree-%F0%9F%8C%B3-lightgreen)](https://offset.earth/stoplightinc)
 
+To report a bug, please go to https://support.stoplight.io
+
 Studio is Stoplight's next generation application for API design, modeling, and technical writing. A primary goal of Studio is to enrich, not replace, your existing workflows. When running locally it works fully offline, with folders and files on your computer just like your favorite IDE. When running in the browser, the web-native Git support allows you to effortlessly work with your existing repositories safely and efficiently.
 
 ## Features


### PR DESCRIPTION
addresses the first half of 
https://github.com/stoplightio/platform-internal/issues/4836

discussion of what the URL should be happening in 
https://github.com/stoplightio/platform-internal/issues/4837